### PR TITLE
memory optimization and duplicated misnamed option removed from json

### DIFF
--- a/configs/configAnalysisMCEM.json
+++ b/configs/configAnalysisMCEM.json
@@ -26,9 +26,8 @@
         "processDummyNoSkimmed": "false"
     },
     "analysis-track-selection": {
-        "cfgTrackCuts": "lmee_GlobalTrackRun2_lowPt,lmee_TPCTrackRun2_lowPt,lmee_TPCTrackRun2,lmee_GlobalTrackRun2,lmee_eNSigmaRun2",
+        "cfgTrackCuts": "lmee_GlobalTrackRun2_lowPt,lmee_TPCTrackRun2_lowPt,lmee_TPCTrackRun2",
         "cfgTrackMCSignals": "electronPrimary,pionPrimary,ePrimaryFromLMeeLFQ,eFromLMeeLFQ,eFromHc,eFromHb",
-        "cfgEffRecWithMC" : "true",
         "cfgUsePtVecEff" : "true",
         "cfgMinPtEff" : "0.",
         "cfgMaxPtEff" : "10.",

--- a/runEMEfficiency.py
+++ b/runEMEfficiency.py
@@ -109,7 +109,14 @@ def main():
     aodFileChecker(args.aod)
     oneToMultiDepsChecker(args.process, "sameEventPairing", args.analysis, "analysis")
     depsChecker(config, sameEventPairingDeps, sameEventPairingTaskName)
+    
 
+    # TODO Prepare global options
+    # disable writer for dilepton producing
+    args.writer = "false"
+    
+    if isinstance(args.aod_memory_rate_limit, type(None)):
+        args.aod_memory_rate_limit = "6000000000"
 
     # Write the updated configuration file into a temporary file
     updatedConfigFileName = "tempConfigEMEfficiencyEE.json"
@@ -117,9 +124,12 @@ def main():
     with open(updatedConfigFileName, "w") as outputFile:
         json.dump(config, outputFile, indent = 2)
 
-    commandToRun = (taskNameInCommandLine + " --configuration json://" + updatedConfigFileName + " -b" + " --aod-writer-json " + args.writer)
+    # NOTE: writer options is now always false for memory optimization (don't need produce any dileptonAod)
+    # commandToRun = (taskNameInCommandLine + " --configuration json://" + updatedConfigFileName + " -b" + " --aod-writer-json " + args.writer)
     if args.writer == "false":
-        commandToRun = (taskNameInCommandLine + " --configuration json://" + updatedConfigFileName + " -b")
+        commandToRun = (taskNameInCommandLine + " --configuration json://" + updatedConfigFileName + " -b" + " --shm-segment-size 12000000000 \
+        --aod-memory-rate-limit " + args.aod_memory_rate_limit)
+        
 
     print("====================================================================================================================")
     logging.info("Command to run:")


### PR DESCRIPTION
@rbailhac 

I want to inform you about one thing. First of all, I tested the python scripts you installed and not skimmed version worked without any problems.

The reason why I opened this PR is that I found 1 small and 1 big problem in the skimmed version.

Minor : 
I deleted one option in json file because it was duplicated and misnamed (cfgEffRecWithMC)

Major:
The most important thing is that O2 consumes a lot of memory for the emEfficiency workflow while processing the data, and when I run the script, I get an overflow error:

`[36194:analysis-track-selection]: Fatal in <TMessage::AutoExpand>: Request to expand to a negative size, likely due to an integer overflow: 0x8146f7b6 for a max of 0x7ffffffe.`

I used the -shm-segment-size 12000000000 option to fix this error, but it still wasn't enough. It consumes so much memory that up to 3 analysis cuts can be applied in the analysis-track-selection task, otherwise an overflow error is received (I tested it many times, I increased the shm segment size and aod-memory-rate-limit a lot, but I think there is a limit for that. there is, that's the most I could solve).

After this changes, it works properly.

So I removed an analysis cut from the json config file and it works fine now. I'm merging this PR for now. If you have a suggestion, we can make future fixes accordingly or we can discuss it further.