### PR TITLE
Change cfg name cfgDalitzCutId to cfgPrefilterCutId

### DIFF
--- a/PythonInterfaceOOP/configs/configAnalysisData.json
+++ b/PythonInterfaceOOP/configs/configAnalysisData.json
@@ -21,7 +21,7 @@
     },
     "analysis-track-selection": {
         "cfgTrackCuts": "jpsiO2MCdebugCuts",
-        "cfgDalitzCutId": "32",
+        "cfgPrefilterCutId": "32",
         "cfgQA": "true",
         "cfgAddTrackHistogram": "dca,its,tpcpid,tofpid",
         "ccdb-url": "http:\/\/alice-ccdb.cern.ch",


### PR DESCRIPTION
The name of the Configurable has changed within the TableReader.
